### PR TITLE
Change worker.send(type, data) to postMessage(data)

### DIFF
--- a/debug/src/main.js
+++ b/debug/src/main.js
@@ -11,20 +11,20 @@ worker.onmessage = function (type, data) {
     if (type === 'bar') {
         console.log('main: got bar from worker');
         console.log('main: sending baz to worker');
-        this.send('baz');
+        this.postMessage({type: 'baz'});
     }
 };
 
 console.log('main: sending foo to worker');
-worker.send('foo');
+worker.postMessage({type: 'foo'});
 
 setTimeout(function () {
     console.log('main: creating worker2');
     var worker2 = new PooledWorker(require('./worker2'));
 
-    worker2.onmessage = function (type, data) {
-        if (type === 'answer') {
-            console.log('main: got answer ' + data + ' from worker2');
+    worker2.onmessage = function (e) {
+        if (e.data.type === 'answer') {
+            console.log('main: got answer ' + e.data.message + ' from worker2');
 
             console.log('main: terminating workers');
             worker.terminate();
@@ -33,5 +33,5 @@ setTimeout(function () {
     }
 
     console.log('main: sending ask to worker2');
-    worker2.send('ask');
+    worker2.postMessage({type: 'ask'});
 }, 200);

--- a/debug/src/worker.js
+++ b/debug/src/worker.js
@@ -6,19 +6,16 @@ module.exports = TestWorker;
 
 function TestWorker() {
     console.log('worker: created');
-    TestWorker.sharedState.push('test');
 };
 
-TestWorker.sharedState = [];
-
 TestWorker.prototype = {
-    onmessage: function (type, data) {
-        if (type === 'foo') {
+    onmessage: function (e) {
+        if (e.data.type === 'foo') {
             console.log('worker: got foo');
             console.log('worker: sending bar');
-            this.send('bar');
+            this.postMessage({type: 'bar'});
         }
-        if (type === 'baz') {
+        if (e.data.type === 'baz') {
             console.log('worker: got baz');
         }
     },

--- a/debug/src/worker2.js
+++ b/debug/src/worker2.js
@@ -10,11 +10,11 @@ function TestWorker2() {
 };
 
 TestWorker2.prototype = {
-    onmessage: function (type, data) {
-        if (type === 'ask') {
+    onmessage: function (e) {
+        if (e.data.type === 'ask') {
             console.log('worker2: got ask');
             console.log('worker2: sending answer');
-            this.send('answer', hello + ' ' + answer);
+            this.postMessage({type: 'answer', message: hello + ' ' + answer});
         }
     },
     onterminate: function () {

--- a/test/basic/index.js
+++ b/test/basic/index.js
@@ -11,15 +11,17 @@ test('roundtrip messages to one worker', function (t) {
     var worker = new PooledWorker(TestWorker);
     t.pass('main: create worker');
 
-    worker.onmessage = function (type, data) {
+    worker.onmessage = function (e) {
+        var type = e.data.type;
+
         if (type === 'bar') {
             t.pass('main: got bar');
 
-            this.send('baz');
+            this.postMessage({type: 'baz'});
             t.pass('main: send baz');
 
         } else if (type === 'end') {
-            t.equal(data, 'Hello', 'main: got end');
+            t.equal(e.data.message, 'Hello', 'main: got end');
             worker.terminate();
             t.pass('worker terminated');
             t.end();
@@ -29,7 +31,7 @@ test('roundtrip messages to one worker', function (t) {
         }
     };
 
-    worker.send('foo');
+    worker.postMessage({type: 'foo'});
     t.pass('main: send foo');
 });
 
@@ -38,19 +40,19 @@ test('delayed worker2 creation and more messages', function (t) {
         var worker2 = new PooledWorker(TestWorker2);
         t.pass('main: create worker2');
 
-        worker2.onmessage = function (type, data) {
-            if (type === 'answer') {
-                t.equal(data, '100 Hello 42', 'main: got answer');
+        worker2.onmessage = function (e) {
+            if (e.data.type === 'answer') {
+                t.equal(e.data.message, '100 Hello 42', 'main: got answer');
                 worker2.terminate();
                 t.pass('worker2 terminated');
                 t.end();
 
             } else {
-                t.fail('main: unexpected message ' + type);
+                t.fail('main: unexpected message ' + e.data.type);
             }
         };
 
-        worker2.send('ask', 100);
+        worker2.postMessage({type: 'ask', message: 100});
         t.pass('main: send ask');
     }, 200);
 });

--- a/test/basic/worker.js
+++ b/test/basic/worker.js
@@ -7,13 +7,14 @@ module.exports = TestWorker;
 function TestWorker() {}
 
 TestWorker.prototype = {
-    onmessage: function (type) {
+    onmessage: function (e) {
+        var type = e.data.type;
         if (type === 'foo') {
-            this.send('bar');
+            this.postMessage({type: 'bar'});
         } else if (type === 'baz') {
-            this.send('end', hello);
+            this.postMessage({type: 'end', message: hello});
         } else {
-            this.send('error');
+            this.postMessage({type: 'error'});
         }
     }
 };

--- a/test/basic/worker2.js
+++ b/test/basic/worker2.js
@@ -8,11 +8,11 @@ module.exports = TestWorker2;
 function TestWorker2() {}
 
 TestWorker2.prototype = {
-    onmessage: function (type, data) {
-        if (type === 'ask') {
-            this.send('answer', data + ' ' + hello + ' ' + answer);
+    onmessage: function (e) {
+        if (e.data.type === 'ask') {
+            this.postMessage({type: 'answer', message: e.data.message + ' ' + hello + ' ' + answer});
         } else {
-            this.send('error');
+            this.postMessage({type: 'error'});
         }
     }
 };


### PR DESCRIPTION
cc @jfirebaugh — this makes the API closer to native Worker API, although I'm still not sure we should do this — the native API is clunky, and if we can't get 100% Worker API parity anyway, should we strive for it?
